### PR TITLE
improve build process

### DIFF
--- a/bash/01_dataloading.sh
+++ b/bash/01_dataloading.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 source bash/config.sh
 
 psql $BUILD_ENGINE --set ON_ERROR_STOP=1 -q -c "

--- a/bash/01_dataloading.sh
+++ b/bash/01_dataloading.sh
@@ -2,7 +2,7 @@
 set -e
 source bash/config.sh
 
-psql $BUILD_ENGINE --set ON_ERROR_STOP=1 -q -c "
+psql $BUILD_ENGINE ON_ERROR_STOP=1 -q -c "
   DROP TABLE IF EXISTS versions;
   CREATE TABLE versions ( 
     datasource text, 
@@ -24,7 +24,7 @@ wait
 rm -rf .library
 
 # Generate source_data_versions table
-psql $BUILD_ENGINE --set ON_ERROR_STOP=1 -1 -c "
+psql $BUILD_ENGINE ON_ERROR_STOP=1 -1 -c "
   DROP TABLE IF EXISTS source_data_versions;
   SELECT 
     datasource as schema_name, 

--- a/bash/01_dataloading.sh
+++ b/bash/01_dataloading.sh
@@ -2,7 +2,7 @@
 set -e
 source bash/config.sh
 
-psql $BUILD_ENGINE ON_ERROR_STOP=1 -q -c "
+psql $BUILD_ENGINE -v ON_ERROR_STOP=1 -q -c "
   DROP TABLE IF EXISTS versions;
   CREATE TABLE versions ( 
     datasource text, 
@@ -24,7 +24,7 @@ wait
 rm -rf .library
 
 # Generate source_data_versions table
-psql $BUILD_ENGINE ON_ERROR_STOP=1 -1 -c "
+psql $BUILD_ENGINE -v ON_ERROR_STOP=1 -1 -c "
   DROP TABLE IF EXISTS source_data_versions;
   SELECT 
     datasource as schema_name, 

--- a/bash/01_dataloading.sh
+++ b/bash/01_dataloading.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 source bash/config.sh
 
-psql $BUILD_ENGINE -q -c "
+psql $BUILD_ENGINE --set ON_ERROR_STOP=1 -q -c "
   DROP TABLE IF EXISTS versions;
   CREATE TABLE versions ( 
     datasource text, 
@@ -23,7 +23,7 @@ wait
 rm -rf .library
 
 # Generate source_data_versions table
-psql $BUILD_ENGINE -1 -c "
+psql $BUILD_ENGINE --set ON_ERROR_STOP=1 -1 -c "
   DROP TABLE IF EXISTS source_data_versions;
   SELECT 
     datasource as schema_name, 

--- a/bash/02_build.sh
+++ b/bash/02_build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 source bash/config.sh
 
 run_sql_file sql/create_priority.sql &

--- a/bash/02_build.sh
+++ b/bash/02_build.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 source bash/config.sh
 
-psql $BUILD_ENGINE -f sql/create_priority.sql &
-psql $BUILD_ENGINE -f sql/preprocessing.sql
-psql $BUILD_ENGINE -f sql/create.sql 
-psql $BUILD_ENGINE -f sql/bbl.sql
+run_sql_file sql/create_priority.sql &
+run_sql_file sql/preprocessing.sql
+run_sql_file sql/create.sql
+run_sql_file sql/bbl.sql
 
 wait
-psql $BUILD_ENGINE -f sql/area_zoningdistrict_create.sql &
-psql $BUILD_ENGINE -f sql/area_commercialoverlay.sql &
-psql $BUILD_ENGINE -f sql/area_specialdistrict.sql &
-psql $BUILD_ENGINE -f sql/area_limitedheight.sql &
-psql $BUILD_ENGINE -f sql/area_zoningmap.sql
+run_sql_file sql/area_zoningdistrict_create.sql &
+run_sql_file sql/area_commercialoverlay.sql &
+run_sql_file sql/area_specialdistrict.sql &
+run_sql_file sql/area_limitedheight.sql &
+run_sql_file sql/area_zoningmap.sql
 
 wait
-psql $BUILD_ENGINE -f sql/area_zoningdistrict.sql 
-psql $BUILD_ENGINE -f sql/parks.sql
-psql $BUILD_ENGINE -f sql/inzonechange.sql
-psql $BUILD_ENGINE -f sql/correct_duplicatevalues.sql
-psql $BUILD_ENGINE -f sql/correct_zoninggaps.sql
-psql $BUILD_ENGINE -f sql/correct_invalidrecords.sql
+run_sql_file sql/area_zoningdistrict.sql
+run_sql_file sql/parks.sql
+run_sql_file sql/inzonechange.sql
+run_sql_file sql/correct_duplicatevalues.sql
+run_sql_file sql/correct_zoninggaps.sql
+run_sql_file sql/correct_invalidrecords.sql
 
 echo "archive final output"
 

--- a/bash/02_build.sh
+++ b/bash/02_build.sh
@@ -3,8 +3,8 @@ set -e
 source bash/config.sh
 
 run_sql_file sql/create_priority.sql &
-run_sql_file sql/preprocessing.sql
 run_sql_file sql/create.sql
+run_sql_file sql/preprocessing.sql
 run_sql_file sql/bbl.sql
 
 wait

--- a/bash/03_qaqc.sh
+++ b/bash/03_qaqc.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 source bash/config.sh
 
 psql $BUILD_ENGINE -f sql/export.sql

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -127,7 +127,7 @@ function import {
   if [ "$existence" == "t" ]; then 
     echo "NAME: $name VERSION: $version is already loaded in postgres!"
   else 
-    psql $BUILD_ENGINE -f $target_dir/$name.sql 
+    psql $BUILD_ENGINE --set ON_ERROR_STOP=1 -f $target_dir/$name.sql 
   fi
   record_version "$name" "$version"
 }

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -132,6 +132,12 @@ function import {
   record_version "$name" "$version"
 }
 
+# Function to run a sql file
+function run_sql_file {
+  psql $BUILD_ENGINE --set ON_ERROR_STOP=1 --file $1
+}
+
+
 # Set Environmental variables
 set_env .env version.env
 

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -137,7 +137,7 @@ function import {
 
 # Function to run a sql file
 function run_sql_file {
-  psql $BUILD_ENGINE ON_ERROR_STOP=1 --file $1
+  psql $BUILD_ENGINE -v ON_ERROR_STOP=1 --file $1
 }
 
 

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -101,7 +101,6 @@ function get_existence {
 }
 
 function import {
-  set -e
   local name=$1
   local version=${2:-latest} #default version to latest
   local acl=$(get_acl $name $version)

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 function set_env {
   for envfile in $@
   do

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -134,7 +134,7 @@ function import {
 
 # Function to run a sql file
 function run_sql_file {
-  psql $BUILD_ENGINE --set ON_ERROR_STOP=1 --file $1
+  psql $BUILD_ENGINE ON_ERROR_STOP=1 --file $1
 }
 
 

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -105,6 +105,7 @@ function get_existence {
 }
 
 function import {
+  set -e
   local name=$1
   local version=${2:-latest} #default version to latest
   local acl=$(get_acl $name $version)

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+
 function set_env {
   for envfile in $@
   do
@@ -128,7 +129,7 @@ function import {
   if [ "$existence" == "t" ]; then 
     echo "NAME: $name VERSION: $version is already loaded in postgres!"
   else 
-    psql $BUILD_ENGINE --set ON_ERROR_STOP=1 -f $target_dir/$name.sql 
+    psql $BUILD_ENGINE ON_ERROR_STOP=1 -f $target_dir/$name.sql 
   fi
   record_version "$name" "$version"
 }

--- a/bash/config.sh
+++ b/bash/config.sh
@@ -2,25 +2,23 @@
 set -e
 
 function set_env {
-  for envfile in $@
-  do
-    if [ -f $envfile ]
-      then
-        export $(cat $envfile | sed 's/#.*//g' | xargs)
-      fi
+  for envfile in $@; do
+    if [ -f $envfile ]; then
+      export $(cat $envfile | sed 's/#.*//g' | xargs)
+    fi
   done
 }
 
 function urlparse {
-    proto="$(echo $1 | grep :// | sed -e's,^\(.*://\).*,\1,g')"
-    url=$(echo $1 | sed -e s,$proto,,g)
-    userpass="$(echo $url | grep @ | cut -d@ -f1)"
-    BUILD_PWD=`echo $userpass | grep : | cut -d: -f2`
-    BUILD_USER=`echo $userpass | grep : | cut -d: -f1`
-    hostport=$(echo $url | sed -e s,$userpass@,,g | cut -d/ -f1)
-    BUILD_HOST="$(echo $hostport | sed -e 's,:.*,,g')"
-    BUILD_PORT="$(echo $hostport | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')"
-    BUILD_DB="$(echo $url | grep / | cut -d/ -f2-)"
+  proto="$(echo $1 | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+  url=$(echo $1 | sed -e s,$proto,,g)
+  userpass="$(echo $url | grep @ | cut -d@ -f1)"
+  BUILD_PWD=$(echo $userpass | grep : | cut -d: -f2)
+  BUILD_USER=$(echo $userpass | grep : | cut -d: -f1)
+  hostport=$(echo $url | sed -e s,$userpass@,,g | cut -d/ -f1)
+  BUILD_HOST="$(echo $hostport | sed -e 's,:.*,,g')"
+  BUILD_PORT="$(echo $hostport | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')"
+  BUILD_DB="$(echo $url | grep / | cut -d/ -f2-)"
 }
 urlparse $BUILD_ENGINE
 
@@ -29,20 +27,20 @@ function SHP_export {
     (
       cd $@
       ogr2ogr -progress -f "ESRI Shapefile" $@.shp \
-          PG:"host=$BUILD_HOST user=$BUILD_USER port=$BUILD_PORT dbname=$BUILD_DB password=$BUILD_PWD" \
-          $@ -nlt MULTIPOLYGON
-        rm -f $@.zip
-        zip $@.zip *
-        ls | grep -v $@.zip | xargs rm
-      )
+        PG:"host=$BUILD_HOST user=$BUILD_USER port=$BUILD_PORT dbname=$BUILD_DB password=$BUILD_PWD" \
+        $@ -nlt MULTIPOLYGON
+      rm -f $@.zip
+      zip $@.zip *
+      ls | grep -v $@.zip | xargs rm
+    )
 }
 
 function CSV_export {
   local table_name=$1
   local output_name=${2:-$1}
-  psql $BUILD_ENGINE  -c "\COPY (
+  psql $BUILD_ENGINE -c "\COPY (
     SELECT * FROM $table_name
-  ) TO STDOUT DELIMITER ',' CSV HEADER;" > $output_name.csv
+  ) TO STDOUT DELIMITER ',' CSV HEADER;" >$output_name.csv
 }
 
 function Upload {
@@ -50,19 +48,17 @@ function Upload {
   mc cp -r output spaces/edm-publishing/db-zoningtaxlots/$@
 }
 
-
 function get_acl {
   local name=$1
   local version=${2:-latest} #default version to latest
   local config_curl=$URL/datasets/$name/$version/config.json
   local statuscode=$(curl --write-out '%{http_code}' --silent --output /dev/null $config_curl)
-  if [[ "$statuscode" -ne 200 ]] ; then
+  if [[ "$statuscode" -ne 200 ]]; then
     echo "private"
   else
     echo "public-read"
   fi
 }
-
 
 function get_version {
   local name=$1
@@ -70,7 +66,7 @@ function get_version {
   local acl=${3:-public-read}
   local config_curl=$URL/datasets/$name/$version/config.json
   local config_mc=spaces/edm-recipes/datasets/$name/$version/config.json
-  if [ "$acl" != "public-read" ] ; then
+  if [ "$acl" != "public-read" ]; then
     local version=$(mc cat $config_mc | jq -r '.dataset.version')
   else
     local version=$(curl -sS $config_curl | jq -r '.dataset.version')
@@ -119,7 +115,7 @@ function import {
     echo "🛠 $name.sql doesn't exists in cache, downloading ..."
     mkdir -p $target_dir && (
       cd $target_dir
-      if [ "$acl" != "public-read" ] ; then
+      if [ "$acl" != "public-read" ]; then
         mc cp spaces/edm-recipes/datasets/$name/$version/$name.sql $name.sql
       else
         curl -O $URL/datasets/$name/$version/$name.sql $name.sql
@@ -127,10 +123,10 @@ function import {
     )
   fi
   # Loading into Database
-  if [ "$existence" == "t" ]; then 
+  if [ "$existence" == "t" ]; then
     echo "NAME: $name VERSION: $version is already loaded in postgres!"
-  else 
-    psql $BUILD_ENGINE ON_ERROR_STOP=1 -f $target_dir/$name.sql 
+  else
+    psql $BUILD_ENGINE -v ON_ERROR_STOP=1 -f $target_dir/$name.sql
   fi
   record_version "$name" "$version"
 }
@@ -139,7 +135,6 @@ function import {
 function run_sql_file {
   psql $BUILD_ENGINE -v ON_ERROR_STOP=1 --file $1
 }
-
 
 # Set Environmental variables
 set_env .env version.env
@@ -153,16 +148,16 @@ VERSION=$DATE
 VERSION_PREV=$(date --date="$(date "+%Y/%m/01") - 1 month" "+%Y/%m/01")
 
 function archive {
-    local src=$1
-    local dst=${2-$src}
-    local src_schema="$(cut -d'.' -f1 <<< "$src")"
-    local src_table="$(cut -d'.' -f2 <<< "$src")"
-    local dst_schema="$(cut -d'.' -f1 <<< "$dst")"
-    local dst_table="$(cut -d'.' -f2 <<< "$dst")"
-    local commit="$(git log -1 --oneline)"
-    local DATE=$(date "+%Y-%m-%d")
-    echo "Dumping $src_schema.$src_table to $dst_schema.$dst_table"
-    psql $EDM_DATA -c "CREATE SCHEMA IF NOT EXISTS $dst_schema;"
-    pg_dump $BUILD_ENGINE -t $src -O -c | sed "s/$src/$dst/g" | psql $EDM_DATA
-    psql $EDM_DATA -c "COMMENT ON TABLE $dst IS '$DATE $commit'"
+  local src=$1
+  local dst=${2-$src}
+  local src_schema="$(cut -d'.' -f1 <<<"$src")"
+  local src_table="$(cut -d'.' -f2 <<<"$src")"
+  local dst_schema="$(cut -d'.' -f1 <<<"$dst")"
+  local dst_table="$(cut -d'.' -f2 <<<"$dst")"
+  local commit="$(git log -1 --oneline)"
+  local DATE=$(date "+%Y-%m-%d")
+  echo "Dumping $src_schema.$src_table to $dst_schema.$dst_table"
+  psql $EDM_DATA -c "CREATE SCHEMA IF NOT EXISTS $dst_schema;"
+  pg_dump $BUILD_ENGINE -t $src -O -c | sed "s/$src/$dst/g" | psql $EDM_DATA
+  psql $EDM_DATA -c "COMMENT ON TABLE $dst IS '$DATE $commit'"
 }

--- a/bash/convert_dtm.sh
+++ b/bash/convert_dtm.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# was run using db-knownprojects-data dev container
+# https://manpages.debian.org/experimental/postgis/shp2pgsql.1.en.html
+# http://www.bostongis.com/pgsql2shp_shp2pgsql_quickguide_20.bqg
+set -e
+echo "Hi! Convert DTM shapefile to PostgreSQL..."
+
+# ogr2ogr dof_dtm_2/dof_dtm_2.sql dof_dtm_1/dof_dtm_1.shp
+shp2pgsql -d -D -I -g wkb_geometry -s 4326 dof_dtm_1/dof_dtm_1.shp public.dof_dtm >dof_dtm_2/dof_dtm_2.sql
+
+echo "Done"

--- a/bash/reproject_dtm.sh
+++ b/bash/reproject_dtm.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# was run using db-data-library dev container
+# https://gdal.org/programs/ogr2ogr.html
+set -e
+echo "Hi! Reprojecting DTM shapefile..."
+
+# ogr2ogr -f "SQlite" -dsco spatialite=yes output.sqlite dof_dtm_0/dof_dtm_tax_lot_polygon.shp -nlt GEOMETRY
+ogr2ogr -makevalid -nlt MULTIPOLYGON -s_srs EPSG:2263 -t_srs EPSG:4326 dof_dtm_1.shp dof_dtm_0/dof_dtm_tax_lot_polygon.shp
+
+echo "Done"

--- a/sql/preprocessing.sql
+++ b/sql/preprocessing.sql
@@ -23,11 +23,6 @@ RENAME COLUMN wkb_geometry TO geom;
 ALTER TABLE dcp_zoningmapindex 
 RENAME COLUMN wkb_geometry TO geom;
 
--- DROP TABLE IF EXISTS dcp_zoning_taxlot;
-
--- ALTER TABLE dcp_zoningtaxlots
--- RENAME TO dcp_zoning_taxlot;
-
 DROP TABLE IF EXISTS dof_dtm_tmp;
 CREATE TABLE dof_dtm_tmp as(
     SELECT 

--- a/sql/preprocessing.sql
+++ b/sql/preprocessing.sql
@@ -35,7 +35,7 @@ CREATE TABLE dof_dtm_tmp as(
         COALESCE(boro::text,LEFT(bbl::text, 1)) as boro, 
         COALESCE(block::text, SUBSTRING(bbl::text, 2, 5)) as block,
         COALESCE(lot::text, SUBSTRING(bbl::text, 7, 4)) as lot,
-        ST_Multi(ST_Union(f.geom)) as geom
+        ST_Multi(ST_Union(ST_MakeValid(f.geom))) as geom
     FROM dof_dtm As f
 GROUP BY bbl, boro, block, lot);
 

--- a/sql/preprocessing.sql
+++ b/sql/preprocessing.sql
@@ -23,10 +23,10 @@ RENAME COLUMN wkb_geometry TO geom;
 ALTER TABLE dcp_zoningmapindex 
 RENAME COLUMN wkb_geometry TO geom;
 
-DROP TABLE IF EXISTS dcp_zoning_taxlot;
+-- DROP TABLE IF EXISTS dcp_zoning_taxlot;
 
-ALTER TABLE dcp_zoningtaxlots
-RENAME TO dcp_zoning_taxlot;
+-- ALTER TABLE dcp_zoningtaxlots
+-- RENAME TO dcp_zoning_taxlot;
 
 DROP TABLE IF EXISTS dof_dtm_tmp;
 CREATE TABLE dof_dtm_tmp as(

--- a/ztl.sh
+++ b/ztl.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 source bash/config.sh
 
 function dataloading { 


### PR DESCRIPTION
## motivations
- failure to import `dof_dtm` started a deep dive into how it's imported
- although multiple bash and SQL errors occurred ([example 1](https://github.com/NYCPlanning/db-zoningtaxlots/actions/runs/4346384942/jobs/7592373135#step:6:25), [example 2](https://github.com/NYCPlanning/db-zoningtaxlots/actions/runs/4441303548/jobs/7796209633#step:5:235)), builds would continue and show green checkmarks. this is a confusing and not a desired behavior

## changes
- add `set -e` to all bash scripts to exit if any command has a non-zero exit status
- add `-v ON_ERROR_STOP=1` to SQL queries in bash files to ensure they stop on errors
- add and use a bash function `run_sql_file` to run all sql files and stop on errors
- fix preprocessing bug around preprocessing
  - was creating and deleting `dcp_zoning_taxlot` without using it and then renaming `dcp_zoningtaxlots` to `dcp_zoning_taxlot` (but `dcp_zoningtaxlots` table never exists)
  - now just creating `dcp_zoning_taxlot`
- add `ST_MakeValid` to preprocessing of `dof_dtm.geom` column to handle latest data ([error in a build](https://github.com/NYCPlanning/db-zoningtaxlots/actions/runs/4442534719/jobs/7798855332#step:6:28))
- autoformat `config.sh`
- add scripts used to re-project and convert `dof_dtm` source data due to data library failing to do so

## notes
- theses changes were used in [latest successful build](https://github.com/NYCPlanning/db-zoningtaxlots/actions/runs/4449254687) and that data has been QAed and pushed to Bytes
- bash scripts related to `dof_dtm` have been added for potential future use. but ideally they're here for reference in a more long-term fix to the issue in data library (https://github.com/NYCPlanning/db-data-library/issues/381)